### PR TITLE
Remove `auth.email`

### DIFF
--- a/src/LightSwitchPlugin.php
+++ b/src/LightSwitchPlugin.php
@@ -64,7 +64,6 @@ class LightSwitchPlugin implements Plugin
     public function shouldShowSwitcher(): bool
     {
         return Str::of(request()->route()->getName())->contains($this->enabledOn ?? [
-            'auth.email',
             'auth.login',
             'auth.password',
             'auth.profile',


### PR DESCRIPTION
- There is no reason to show the buttons on `auth.email` route, since there's already a profile menu which the user can toggle the dark mode from.
- Shows on the top of the profile menu, preventing the user from clicking on it.