### PR TITLE
Fix: lower z-index switcher to 40 to prevent overlap with Filament notifications

### DIFF
--- a/resources/views/switcher.blade.php
+++ b/resources/views/switcher.blade.php
@@ -9,7 +9,7 @@
     $plugin->shouldShowSwitcher()
 )
     <div @class([
-        'auth-theme-switcher fixed w-full flex p-4 z-50',
+        'auth-theme-switcher fixed w-full flex p-4 z-40',
         'top-0' => str_contains($alignment, 'top'),
         'bottom-0' => str_contains($alignment, 'bottom'),
         'justify-start' => str_contains($alignment, 'left'),


### PR DESCRIPTION
Fix issue where the switcher overlaps Filament notifications.
The `z-index` for Filament notifications is 50, so I lowered the switcher's `z-index` to 40.

![image](https://github.com/user-attachments/assets/bbe2c691-8db3-4593-a47d-4695cd3d9d0e)
