### PR TITLE
fix(theme): use default theme mode from filament defaultThemeMode

### DIFF
--- a/resources/views/switcher.blade.php
+++ b/resources/views/switcher.blade.php
@@ -22,7 +22,7 @@
                     theme: null,
 
                     init: function () {
-                        this.theme = localStorage.getItem('theme') || 'system'
+                        this.theme = localStorage.getItem('theme') || @js(filament()->getDefaultThemeMode()->value)
 
                         $dispatch('theme-changed', theme)
 


### PR DESCRIPTION
This PR is to make default theme mode of switcher as the value returned from defaultThemeMode  instead  'system'